### PR TITLE
Fix NSD ip-parsing regex

### DIFF
--- a/templates/var/nsd/etc/nsd.conf
+++ b/templates/var/nsd/etc/nsd.conf
@@ -11,5 +11,5 @@ zone:
 	zonefile: "{{ domain }}"
 
 zone:
-	name: "{{ gw_network | regex_replace('^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$','\\3.\\2.\\\1')}}.in-addr.arpa"
-	zonefile: "{{ gw_network | regex_replace('^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$','\\3.\\2.\\\1')}}.in-addr.arpa"
+	name: "{{ gw_network | regex_replace('^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$','\\3.\\2.\\1')}}.in-addr.arpa"
+	zonefile: "{{ gw_network | regex_replace('^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$','\\3.\\2.\\1')}}.in-addr.arpa"


### PR DESCRIPTION
There's an extra \ before the \1, which leads to a bad config
