### PR TITLE
Fix mirror path in pkg.conf

### DIFF
--- a/files/etc/pkg.conf
+++ b/files/etc/pkg.conf
@@ -1,1 +1,1 @@
-installpath = http://mirror.esc7.net/pub/OpenBSD/%m/
+installpath = http://mirror.esc7.net/%m/


### PR DESCRIPTION
%m expands to full mirror path, and includes /pub/OpenBSD already.
